### PR TITLE
Add Slack avatars

### DIFF
--- a/userscript.user.js
+++ b/userscript.user.js
@@ -45816,6 +45816,12 @@ var $$IMU_EXPORT$$;
 			};
 		}
 
+		if (domain === "ca.slack-edge.com") {
+			// https://ca.slack-edge.com/T81EQ2QNM-UDEDDF8AV-c0aac75e8652-72
+			//   https://ca.slack-edge.com/T81EQ2QNM-UDEDDF8AV-c0aac75e8652-1024
+			return src.replace(/-\d+$/, "-1024");
+		}
+
 
 
 


### PR DESCRIPTION
Notes:
- Removing the resolution suffix results in an error, so we can't do that
- You can theoretically append a higher number than 1024 to the URL, but Slack resizes avatars to 1024 x 1024 px on upload (see https://slack.com/help/articles/115005506003).